### PR TITLE
Refactor API URL calls and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,32 @@ pip install -r requirements.txt
 ```
 
 For Windows you could use Anaconda or Miniconda. For Linux you could use Miniconda. There are several installation
-guides on the internet.in
+guides on the internet.
+
+## Environment variables
+
+To run the test cases and the other parts of the script, you need to define the API key and the API url to access the
+5GLa API. You can
+set the following environment variables:
+
+| Variable | Description                         |
+|----------|-------------------------------------|
+| API_KEY  | The API key to access the 5GLa API. |
+| API_URL  | The URL to access the 5GLa API.     |
+
+There are currently two stages to access the 5GLa API:
+
+| Stage | URL                             |
+|-------|---------------------------------|
+| DEV   | https://api.dev.5gla.de/api/v1/ |
+| QA    | https://api.qa.5gla.de/api/v1/  |
+
+## Where to find the API key
+
+If you need an API, please have a look at the configuration for the stages. You can find the API key in the private GIT
+repository.
+
+| Stage | Link                                                                                                                  |
+|-------|-----------------------------------------------------------------------------------------------------------------------|
+| DEV   | https://github.com/vitrum-connect/5gla-cluster-config/blob/stages/dev/config/k8s/configmaps/fivegla-api-configmap.yml |
+| QA    | https://github.com/vitrum-connect/5gla-cluster-config/blob/stages/qa/config/k8s/configmaps/fivegla-api-configmap.yml  |

--- a/src/integration/api_integration_service.py
+++ b/src/integration/api_integration_service.py
@@ -15,7 +15,7 @@ class ApiIntegrationService:
         Checks the availability of the 5GLA API.
             """
         config_manager = ConfigManager()
-        url = config_manager.get('api_url') + config_manager.get('api_version_endpoint')
+        url = config_manager.get_env('API_URL') + config_manager.get('api_version_endpoint')
         headers = {'X-API-Key': config_manager.get_env('API_KEY')}
         response = requests.get(url=url, headers=headers)
         if response.status_code == 200:

--- a/src/integration/sensor_data/agvolution/agvolution_integration_service.py
+++ b/src/integration/sensor_data/agvolution/agvolution_integration_service.py
@@ -40,7 +40,7 @@ class AgvolutionIntegrationService:
         - url (str): The constructed URL for data logging in Agvolution.
 
         """
-        return self._config_manager.get('api_url') + self._config_manager.get(
+        return self._config_manager.get_env('API_URL') + self._config_manager.get(
             'api_agvolution_data_logging_endpoint') + "/" + sensor_id
 
     def _transform_sensor_data_to_request_body(self, sensor_data):

--- a/src/integration/sensor_data/common_sensor_integration_service.py
+++ b/src/integration/sensor_data/common_sensor_integration_service.py
@@ -41,7 +41,7 @@ class CommonSensorDataIntegrationService:
             'X-API-Key': config_manager.get_env('API_KEY'),
             'Content-Type': 'application/json'
         }
-        url = config_manager.get('api_url') + config_manager.get('device_registration_endpoint')
+        url = config_manager.get_env('API_URL') + config_manager.get('device_registration_endpoint')
         response = requests.post(url=url, headers=headers,
                                  data=RegisterDeviceRequest(manufacturer=manufacturer, id=sensor_id, latitude=latitude,
                                                             longitude=longitude).as_json())

--- a/src/integration/sensor_data/sentek/sentek_integration_service.py
+++ b/src/integration/sensor_data/sentek/sentek_integration_service.py
@@ -61,7 +61,7 @@ class SentekIntegrationService:
             https://api.example.com/sentek-data-logging/ABC123
 
         """
-        return self._config_manager.get('api_url') + self._config_manager.get(
+        return self._config_manager.get_env('API_URL') + self._config_manager.get(
             'api_sentek_data_logging_endpoint') + "/" + sensor_id
 
     def _transform_sensor_data_to_request_body(self, sensor_data):

--- a/src/integration/sensor_data/weenat/weenat_integration_service.py
+++ b/src/integration/sensor_data/weenat/weenat_integration_service.py
@@ -43,7 +43,7 @@ class WeenatIntegrationService:
         :return: The URL for logging sensor data for the specified sensor.
         :rtype: str
         """
-        return self._config_manager.get('api_url') + self._config_manager.get(
+        return self._config_manager.get_env('API_URL') + self._config_manager.get(
             'api_weenat_data_logging_endpoint') + "/" + sensor_id
 
     def _transform_sensor_data_to_request_body(self, sensor_data):


### PR DESCRIPTION
This commit replaces 'config_manager.get' calls with 'config_manager.get_env' to load the API URL as an environment variable in common_sensor_integration_service.py, api_integration_service.py, weenat_integration_service.py, sentek_integration_service.py, and agvolution_integration_service.py.

Additionally, the README.md file was updated to reflect these changes and provide details on setting environment variables and where to retrieve the API key. Since the API URL will now be loaded from an environment variable, this update is vital for providing clear instructions on the new configuration to the users and developers.